### PR TITLE
Support linked record fields

### DIFF
--- a/settings.example.json
+++ b/settings.example.json
@@ -8,6 +8,13 @@
 
       "airtable_table": "Words",
       "airtable_view": "Learning",
+      "airtable_linked_record_fields": [
+        {
+          "field": "Origin",
+          "table": "Languages of Origin",
+          "primary_field": "Language"
+        }
+      ]
       "airtable_key": "https://airtable.com/api <-- find here"
     }
   ]


### PR DESCRIPTION
If a table has a Linked Record field, the Airtable API response contains
record IDs that look something like "rec1234567890123" instead of
something intelligible.  What we probably want instead is the value of
the linked record's (or linked records') primary field.  This commit
adds support for fetching those values.

The way this is written, the user must add some configuration in
settings.json for each linked record field: the name of the field, the
table to which it links, and the name of that table's primary field.
Ideally, all of this could be inferred automatically, and it is indeed
possible to guess when a field's value consists of record IDs using a
regex, but unfortunately, the Airtable API doesn't offer a way to
discover a linked record field's linked table or the table's primary
field.  Hence, the need to ask the user for explicit configuration.

It's possible to add some intelligent defaults, e.g. assume the field,
the table, and the table's primary field are all the same, but as the
exact desired behavior is debatable, I leave it for another time.

It's also worth noting that the performance is not ideal as we execute
N+1 API requests.  I also leave that to be solved another day.