### PR TITLE
fix(import): save model after assigning deck

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -166,6 +166,7 @@ def airtableImport(col, deck, modelName, table, view, app_key):
         mw.col.models.addTemplate(model, template)
 
     model['did'] = did
+    mw.col.models.save(model)
 
     deck = mw.col.decks.get(did)
     deck['mid'] = model['id']

--- a/__init__.py
+++ b/__init__.py
@@ -113,7 +113,7 @@ class AirtableImporter(NoteImporter):
         if "offset" in json_response:
             records += self.getRecordsWithOffset(json_response["offset"])
 
-        return records
+        return [r for r in records if r.get('fields', {}).get('Status') == 'Complete']
 
     def downloadToCollection(self, media):
         field = ""


### PR DESCRIPTION
Fixes  #17 

This fixes an issue where all imported cards are added to the 'Default' deck, instead of the deck specified in the plugin config.

Resources:
https://forums.ankiweb.net/t/importnotes-always-adds-cards-to-default-deck/1690/3
https://addon-docs.ankiweb.net/#/getting-started?id=the-collection